### PR TITLE
Give player context to favorites emit

### DIFF
--- a/lib/sonos.js
+++ b/lib/sonos.js
@@ -242,7 +242,8 @@ function Discovery() {
 
           player.getFavorites(function (success, favorites) {
             if (!success) return;
-            _this.emit('favorites', favorites);
+            notifyState.favorites=favorites;
+            _this.emit('favorites', notifyState);
           });
         } else {
           _this.emit('notify', notifyState);


### PR DESCRIPTION
In a system with a bunch of zones, a change to favorites results in a bunch of "favorites" emits, all with the exact same information. This change includes the sid (and nts and type) so the developer can at least filter by zone (even though all the favorites are the same).

This will obviously break existing installs. I just wanted to forward the changes that have helped my code. 
