### PR TITLE
Ignore all but first fav blast.

### DIFF
--- a/lib/sonos.js
+++ b/lib/sonos.js
@@ -69,6 +69,7 @@ function Discovery() {
   var groupVolumeTimer;
   var socketBindSuccess = false;
   this.toggleLED = false;
+  this.ignoreFavoritesEvents = false;
 
   // create a notify server, this will handle all events.
   var eventServer = http.createServer(handleEventNotification);
@@ -232,18 +233,23 @@ function Discovery() {
             _this.emit('queue-changed', {uuid: RegExp.$1});
         } else if (elem == "FavoritesUpdateID") {
           console.log("FavoritesUpdateID", notifyState);
-          var player;
-          for (var i in _this.players) {
-            player = _this.players[i];
-            break;
+          if (!_this.ignoreFavoritesEvents) {
+            _this.ignoreFavoritesEvents = true;
+            clearTimeout(_this.ignoreFavoritesEventsTimeout);
+            _this.ignoreFavoritesEventsTimeout = setTimeout(function () { _this.ignoreFavoritesEvents = false; }, 500);
+            var player;
+            for (var i in _this.players) {
+              player = _this.players[i];
+              break;
+            }
+  
+            if (!player) return;
+  
+            player.getFavorites(function (success, favorites) {
+              if (!success) return;
+              _this.emit('favorites', favorites);
+            });
           }
-
-          if (!player) return;
-
-          player.getFavorites(function (success, favorites) {
-            if (!success) return;
-            _this.emit('favorites', favorites);
-          });
         } else {
           _this.emit('notify', notifyState);
         }


### PR DESCRIPTION
When a favorite element is received, emit it, but set up a timer that will ignore any other favorites for the next 500ms. This will avoid sending n (where n is the number of Sonos Zones) favorite emits all with the exact same payload.
