### PR TITLE
Player name removal of XML entities

### DIFF
--- a/lib/player.js
+++ b/lib/player.js
@@ -67,10 +67,11 @@ function Player(roomName, descriptorUrl, uuid, discovery) {
   var _this = this;
   var positionInfoTimeout;
   var sids = {};
+  var xmlEntities = new XmlEntities();
   // for prototype access
   this.discovery = discovery;
   this.address = descriptorUrl.replace(/http:\/\/([\d\.]+).*/, "$1");
-  this.roomName = roomName;
+  this.roomName = xmlEntities.decode(roomName);
   this.zoneType = 0;
   this.uuid = uuid;
   this.state = {


### PR DESCRIPTION
Fixes the encoding issue mentioned in the web controller issue:
https://github.com/jishi/node-sonos-web-controller/issues/13

This then resolves the issue for anything that uses it.

The encoding issue doesn't seem to impact any other fields.
