### PR TITLE
Ignore false-positives when subscribing

### DIFF
--- a/lib/sonos.js
+++ b/lib/sonos.js
@@ -91,11 +91,12 @@ function Discovery() {
 
   this.notificationPort = 3500;
 
+  var SONOS_PLAYER_UPNP_URN = 'urn:schemas-upnp-org:device:ZonePlayer:1';
   var PLAYER_SEARCH = new Buffer(["M-SEARCH * HTTP/1.1",
     "HOST: 239.255.255.250:reservedSSDPport",
     "MAN: ssdp:discover",
     "MX: 1",
-    "ST: urn:schemas-upnp-org:device:ZonePlayer:1"].join("\r\n"));
+    "ST: " + SONOS_PLAYER_UPNP_URN].join("\r\n"));
 
     // use random port to allow for multiple instances
     var port = 1902 + Math.round(Math.random(Date.now()) * 800);
@@ -128,6 +129,11 @@ function Discovery() {
     var socket = dgram.createSocket('udp4', function(buffer, rinfo) {
 
       var response = buffer.toString('ascii');
+      if(response.indexOf(SONOS_PLAYER_UPNP_URN) === -1) {
+        // Ignore false positive from badly-behaved non-Sonos device.
+        return; 
+      }
+
       var headers = response.split('\r\n');
 
       if (_this.knownPlayers.indexOf(rinfo.address) > -1) {


### PR DESCRIPTION
When attempting to subscribe to a Sonos player, we sometimes get false-positives from other types of device (e.g. a Philips Hue bridge.)

The discovery code has been patched to ignore any non-Sonos device.
