### PR TITLE
Introduce logging module for ability to control output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+*.swp

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,0 +1,22 @@
+var logger = exports; exports.constructor = function logger(){};
+
+var winston = require('winston');
+
+var LOG_LEVEL = process.env.NODE_ENV === 'development' ? 'info' : 'error';
+
+logger.initialize = function() {
+  var client = new (winston.Logger)({
+    transports: [
+      new (winston.transports.Console)({ level: LOG_LEVEL })
+    ]
+  });
+
+  // Override the log level from the process env
+  if (process.env.DISCOVERY_LOG_LEVEL) {
+    client.transports.console.level = process.env.DISCOVERY_LOG_LEVEL;
+  }
+
+  logger.client = client;
+
+  return logger.client;
+};

--- a/lib/player.js
+++ b/lib/player.js
@@ -72,6 +72,7 @@ function Player(roomName, descriptorUrl, uuid, discovery) {
   var xmlEntities = new XmlEntities();
   // for prototype access
   this.discovery = discovery;
+  this.log = this.discovery.log;
   this.address = descriptorUrl.replace(/http:\/\/([\d\.]+).*/, "$1");
   this.roomName = xmlEntities.decode(roomName);
   this.zoneType = 0;
@@ -144,7 +145,7 @@ function Player(roomName, descriptorUrl, uuid, discovery) {
     var saxParser = new EasySax();
 
     saxParser.on('error', function (e) {
-      console.error(e);
+      _this.log.error(e);
     });
 
     var event = {
@@ -201,7 +202,7 @@ function Player(roomName, descriptorUrl, uuid, discovery) {
     if (data.CurrentTrackMetaData) {
       var saxParser = new EasySax();
       saxParser.on('error', function (e) {
-        console.error(e);
+        _this.log.error(e);
       });
 
       var nodeValue = "";
@@ -230,7 +231,7 @@ function Player(roomName, descriptorUrl, uuid, discovery) {
     if (data['r:NextTrackMetaData']) {
       var saxParser = new EasySax();
       saxParser.on('error', function (e) {
-        console.error(e);
+        _this.log.error(e);
       });
 
       var nodeValue = "";
@@ -309,7 +310,7 @@ function Player(roomName, descriptorUrl, uuid, discovery) {
       res.setEncoding("utf-8");
 
       res.on('error', function (e) {
-        console.error(e);
+        _this.log.error(e);
       });
 
       res.on('data', function (chunk) {
@@ -337,7 +338,7 @@ function Player(roomName, descriptorUrl, uuid, discovery) {
       });
     });
     req.on("error", function (e) {
-      console.error(e);
+      _this.log.error(e);
     });
     req.write(SOAP.PositionInfo);
     req.end();
@@ -379,7 +380,7 @@ function Player(roomName, descriptorUrl, uuid, discovery) {
         subscription.resubscribeTimer = setTimeout(function () { subscribe(path); }, subscriptionTimeout * 500);
       } else {
         // Some error occured, try to resubscribe
-        console.error("subscribe failed", subscription.sid, path, res.statusCode);
+        _this.log.error("subscribe failed", subscription.sid, path, res.statusCode);
         delete subscription.sid;
         clearTimeout(subscription.resubscribeTimer);
         subscription.resubscribeTimer = setTimeout(function () { subscribe(path); }, 5000);
@@ -389,7 +390,7 @@ function Player(roomName, descriptorUrl, uuid, discovery) {
     });
 
     client.on('error', function (e) {
-      console.error(e, subscription.sid, path);
+      _this.log.error(e, subscription.sid, path);
       // Keep trying...
       delete subscription.sid;
       clearTimeout(subscription.resubscribeTimer);
@@ -456,7 +457,7 @@ Player.prototype.soapAction = function (path, action, soap, callback) {
       }},
       function (res) {
         var body = [];
-        //console.log(_this.roomName, action, 'STATUS: ' + res.statusCode);
+        //_this.log.info(_this.roomName, action, 'STATUS: ' + res.statusCode);
         if (!callback) return;
         if (res.statusCode != 200) {
           callback(false);
@@ -470,7 +471,7 @@ Player.prototype.soapAction = function (path, action, soap, callback) {
   req.setTimeout(1000);
 
   req.on('error', function(e) {
-    console.error("error occured on soap request", e.message);
+    _this.log.error("error occured on soap request", e.message);
     if (!callback) return;
     callback(false, this);
   });
@@ -731,12 +732,12 @@ Player.prototype.replaceWithFavorite = function (favorite, callback) {
 
   player.getFavorites(function (success, favorites) {
     if (!success) {
-      console.error("error when fetching favorites");
+      player.log.error("error when fetching favorites");
       return;
     }
     favorites.forEach(function (item) {
       if (item.title.toLowerCase() == decodeURIComponent(favorite).toLowerCase()) {
-        console.log("found it", item)
+        player.log.info("found it", item)
 
         if (item.uri.startsWith("x-sonosapi-stream:") || item.uri.startsWith("x-sonosapi-radio:") || item.uri.startsWith("pndrradio:")) {
           // This is a radio station, use setAVTransportURI instead.
@@ -748,14 +749,14 @@ Player.prototype.replaceWithFavorite = function (favorite, callback) {
 
         player.removeAllTracksFromQueue(function (success) {
           if (!success) {
-            console.error("error when removing tracks");
+            player.log.error("error when removing tracks");
             callback(false);
             return;
           }
 
           player.addURIToQueue(item.uri, item.metaData, function (success) {
             if (!success) {
-              console.error("problem adding URI to queue");
+              player.log.error("problem adding URI to queue");
               callback(false);
               return;
             }
@@ -774,7 +775,7 @@ Player.prototype.addPlaylistToQueue = function(playlistURI, callback){
   var player = this;
   player.addURIToQueue(playlistURI, '', function(success){
     if(!success){
-      console.error("problem loading playlist");
+      player.log.error("problem loading playlist");
       callback(false);
       return;
     }
@@ -790,7 +791,7 @@ Player.prototype.replaceQueueWithPlaylist = function(playlistURI, callback){
   var player = this;
   player.removeAllTracksFromQueue(function (success) {
     if (!success) {
-      console.error("error when removing tracks");
+      player.log.error("error when removing tracks");
       callback(false);
       return;
     }

--- a/lib/sonos.js
+++ b/lib/sonos.js
@@ -11,6 +11,8 @@ var dgram = require('dgram'),
   Player = require('./player.js'),
   Sub = require('./sub.js');
 
+var logger = require('./logger');
+
 String.prototype.startsWith = function (str) {
   return this.indexOf(str) === 0;
 }
@@ -71,6 +73,8 @@ function Discovery(settings) {
   this.toggleLED = false;
   this.ignoreFavoritesEvents = false;
 
+  this.log = logger.initialize();
+
   settings = settings || {
     household: null
   };
@@ -104,7 +108,7 @@ function Discovery(settings) {
 
   // use random port to allow for multiple instances
   var port = 1902 + Math.round(Math.random(Date.now()) * 800);
-  console.log("binding SSDP to port", port);
+  this.log.info("binding SSDP to port", port);
 
   var interfaces = os.networkInterfaces();
 
@@ -114,7 +118,7 @@ function Discovery(settings) {
   var sockets = {'dummy': null};
 
   for (var name in interfaces) {
-    console.log('discovering all IPs from', name);
+    _this.log.info('discovering all IPs from', name);
     interfaces[name].forEach(function (ipInfo) {
       if (ipInfo.internal == false && ipInfo.family == "IPv4") {
         // this one is interesting, use it
@@ -124,7 +128,7 @@ function Discovery(settings) {
     });
   }
 
-  console.log("relevant IPs", sockets);
+  this.log.info("relevant IPs", sockets);
 
   // Now, create a socket for each ip
 
@@ -169,7 +173,7 @@ function Discovery(settings) {
     });
 
     socket.on('error', function (e) {
-      console.error(e);
+      _this.log.error(e);
     });
 
     socket.on('listening', function (socket) {
@@ -195,7 +199,7 @@ function Discovery(settings) {
 
   function scanDevices() {
     for (var ip in sockets) {
-      console.log("scanning for players in ip", ip);
+      _this.log.info("scanning for players in ip", ip);
       var socket = sockets[ip];
       socket.send(PLAYER_SEARCH, 0, PLAYER_SEARCH.length, 1900, '239.255.255.250');
       clearTimeout(timeout);
@@ -221,7 +225,7 @@ function Discovery(settings) {
       };
 
       saxParser.on('error', function (e) {
-        console.error(e, buffer.join(""));
+        _this.log.error(e, buffer.join(""));
       });
 
       var nodeContent;
@@ -260,7 +264,7 @@ function Discovery(settings) {
           _this.emit('notify', notifyState);
         }
          // else if (elem == "FavoritesUpdateID") {
-        //   console.log("FavoritesUpdateID", notifyState);
+        //   this.log.info("FavoritesUpdateID", notifyState);
         //   var player;
         //   for (var i in _this.players) {
         //     player = _this.players[i];
@@ -274,7 +278,7 @@ function Discovery(settings) {
         //     _this.emit('favorites', favorites);
         //   });
         // } else if (elem == "ContainerUpdateIDs"  && notifyState.body.indexOf('Q:0') > -1) {
-        //   console.log("ContainerUpdateIDs", notifyState);
+        //   this.log.info("ContainerUpdateIDs", notifyState);
         //   return;
         //   if (/uuid:(.+)_sub/.test(notifyState.sid))
         //     _this.emit('queue-changed', {uuid: RegExp.$1});
@@ -292,7 +296,7 @@ function Discovery(settings) {
       // if (notifyState.type == "ZoneGroupState") {
 
       // } else if (notifyState.type == "FavoritesUpdateID") {
-      //   console.log("FavoritesUpdateID", notifyState);
+      //   this.log.info("FavoritesUpdateID", notifyState);
       //   var player;
       //   for (var i in _this.players) {
       //     player = _this.players[i];
@@ -306,13 +310,13 @@ function Discovery(settings) {
       //     _this.emit('favorites', favorites);
       //   });
       // } else if (notifyState.type == "ContainerUpdateIDs"  && notifyState.body.indexOf('Q:0') > -1) {
-      //   console.log("ContainerUpdateIDs", notifyState);
+      //   this.log.info("ContainerUpdateIDs", notifyState);
       //   return;
       //   if (/uuid:(.+)_sub/.test(notifyState.sid))
       //     _this.emit('queue-changed', {uuid: RegExp.$1});
       // } else {
       //   // if (notifyState.type == "LastChange")
-      //   //   console.log(notifyState);
+      //   //   this.log.info(notifyState);
       //   _this.emit('notify', notifyState);
       // }
     });
@@ -408,7 +412,7 @@ function Discovery(settings) {
       return;
     }
 
-    console.log("subscribing to topology", address);
+    _this.log.info("subscribing to topology", address);
 
     _this.subscribedTo = address;
 
@@ -429,7 +433,7 @@ function Discovery(settings) {
       // In case of multiple interfaces!
       _this.localEndpoint = res.socket.address().address;
 
-      console.log("using local endpoint", _this.localEndpoint);
+      _this.log.info("using local endpoint", _this.localEndpoint);
 
       // We don't need anything more, subscribe
       subscribe('/ZoneGroupTopology/Event');
@@ -466,7 +470,7 @@ function Discovery(settings) {
   //   });
 
   //   client.on('error', function (e) {
-  //     console.error(e);
+  //     _this.log.error(e);
   //   });
 
   //   client.end();
@@ -492,7 +496,7 @@ function Discovery(settings) {
   //     method: 'SUBSCRIBE',
   //     headers: headers
   //   }, function (res) {
-  //     console.log(res.headers);
+  //     _this.log.info(res.headers);
   //     // Store some relevant headers?
   //     if (!callback) {
   //       return;
@@ -512,7 +516,7 @@ function Discovery(settings) {
 
   //   client.on('error', function (e) {
   //     // If this fails, this player has fallen of the grid
-  //     console.error(e);
+  //     _this.log.error(e);
   //     callback && callback(false);
   //   });
 
@@ -545,7 +549,7 @@ function Discovery(settings) {
 
         setTimeout(function () { subscribe(path); }, subscriptionTimeout * 500);
       } else {
-        console.error("subscribe failed!", sids[path], res.statusCode);
+        _this.log.error("subscribe failed!", sids[path], res.statusCode);
         // we lost the subscription, clear sid
         delete sids[path];
         // try again in 30 seconds
@@ -555,7 +559,7 @@ function Discovery(settings) {
 
     client.on('error', function (e) {
       // If this fails, this player has fallen of the grid
-      console.error(e);
+      _this.log.error(e);
     });
 
     client.end();
@@ -599,20 +603,20 @@ function Discovery(settings) {
   this.aggregateGroupVolume = function (volumeData) {
     clearTimeout(groupVolumeTimer);
     groupVolumeTimer = setTimeout(function () {
-      console.log('emitting group-volume');
+      _this.log.info('emitting group-volume');
       _this.emit('group-volume', volumeData);
     }, 100);
   }
 
   eventServer.on('error', function (e) {
     if (e.code == 'EADDRINUSE') {
-      console.error("port in use", _this.notificationPort, "trying new one");
+      _this.log.error("port in use", _this.notificationPort, "trying new one");
       startServerOnPort(++_this.notificationPort);
     }
   });
 
   eventServer.on('listening', function () {
-    console.log("notification server listening on port", _this.notificationPort);
+    _this.log.info("notification server listening on port", _this.notificationPort);
   });
 
 
@@ -681,11 +685,11 @@ Discovery.prototype.getSubByUUID = function (uuid) {
 //  }
 
 Discovery.prototype.applyPreset = function (preset, callback) {
-  console.log("applying preset", preset);
+  this.log.info("applying preset", preset);
   // cache this reference for closure access
   var _this = this;
   if (!preset.players || preset.players.length == 0) {
-    console.error("your preset doesn't contain any players");
+    this.log.error("your preset doesn't contain any players");
     return;
   }
   var playerInfo = preset.players[0];
@@ -710,7 +714,7 @@ Discovery.prototype.applyPreset = function (preset, callback) {
   // If coordinator already is coordinator, skip becomeCoordinatorOfStandaloneGroup
   // If only one player in preset, it should breakout never the less.
   if (coordinator.coordinator.uuid == coordinator.uuid && preset.players.length > 1) {
-    console.log("skipping breakout because already coordinator");
+    this.log.info("skipping breakout because already coordinator");
     // Instead we need to detach the players that don't belong.
     // Find the zone
     var zone;
@@ -739,7 +743,7 @@ Discovery.prototype.applyPreset = function (preset, callback) {
 
   } else {
     // This one is not coordinator, just detach it and leave it be.
-    console.log("ungrouping", coordinator.roomName, "to prepare for grouping");
+    this.log.info("ungrouping", coordinator.roomName, "to prepare for grouping");
     asyncSeries.push(function (callback) {
       coordinator.becomeCoordinatorOfStandaloneGroup(function (success) {
         callback(null, success);
@@ -780,7 +784,7 @@ Discovery.prototype.applyPreset = function (preset, callback) {
     var playerInfo = preset.players[i];
     var player = _this.getPlayer(playerInfo.roomName);
     if (!player) {
-      console.error("invalid playerName", playerInfo.roomName);
+      _this.log.error("invalid playerName", playerInfo.roomName);
       continue;
     }
     var streamUrl = "x-rincon:" + coordinator.uuid;
@@ -813,7 +817,7 @@ Discovery.prototype.applyPreset = function (preset, callback) {
 
 Discovery.prototype.setToggleLED = function (enabled) {
   this.toggleLED = enabled;
-   console.log("update players with setToggleLED");
+  this.log.info("update players with setToggleLED");
 
   this.on('transport-state', function (player) {
 

--- a/lib/sub.js
+++ b/lib/sub.js
@@ -69,6 +69,7 @@ function Sub(roomName, descriptorUrl, uuid, discovery) {
   var sids = {};
   // for prototype access
   this.discovery = discovery;
+  this.log = this.discovery.log;
   this.address = descriptorUrl.replace(/http:\/\/([\d\.]+).*/, "$1");
   this.roomName = roomName;
   this.zoneType = 0;
@@ -241,7 +242,7 @@ Sub.prototype.soapAction = function (path, action, soap, callback) {
       }},
       function (res) {
         var body = [];
-        console.log(_this.roomName, action, 'STATUS: ' + res.statusCode);
+        _this.log.info(_this.roomName, action, 'STATUS: ' + res.statusCode);
         if (!callback) return;
         if (res.statusCode != 200) {
           callback(false);

--- a/package.json
+++ b/package.json
@@ -8,9 +8,10 @@
     "url": "https://github.com/jishi/node-sonos-discovery.git"
   },
   "dependencies": {
-    "easysax": "0.1.x",
     "async": "0.2.x",
-    "html-entities": "1.0.x"
+    "easysax": "0.1.x",
+    "html-entities": "1.0.x",
+    "winston": "0.8.3"
   },
   "engine": "node 0.8.x",
   "main": "lib/sonos.js"


### PR DESCRIPTION
This adds a basic logging module so that the output of this module can be controlled by its user. By default the log level is set to `error`, but when `NODE_ENV` is `development` it is set to `info`.

Additionally, the user may override without using `NODE_ENV` by setting `DISCOVERY_LOG_LEVEL` to an approved winston console transport log level.

Very helpful when debugging an application which consumes `node-sonos-discovery` so that the internal logging doesn't drown out application logging.
