### PR TITLE
Add functionality to retrieve accounts from Sonos

### DIFF
--- a/lib/player.js
+++ b/lib/player.js
@@ -83,6 +83,58 @@ function parseMetaDataXML(xml) {
   return result;
 }
 
+function parseAccountsXml(xml) {
+  var result = [];
+  var saxParser = new EasySax();
+  var nodeValue;
+  var currentItem = {};
+  var currentAttr = {};
+
+  var mapping = {
+    'UN': 'username',
+    'NN': 'nickname',
+  };
+
+  var mapping_attr = {
+    'Type': 'type',
+    'SerialNum': 'sn',
+    'Deleted': 'deleted'
+  };
+
+  saxParser.on('textNode', function (str, uq) {
+    nodeValue = uq(str);
+  });
+
+  saxParser.on('startNode', function (elem, attr) {
+    nodeValue = '';
+    if (elem == 'Account') {
+      var attributes = attr();
+      for (var key in attributes) {
+        if (mapping_attr[key] === undefined) { continue; }
+        currentAttr[mapping_attr[key]] = attributes[key] || '';
+      }
+    }
+  });
+
+  saxParser.on('endNode', function(elem, unEntities, tagstart, getStringNode) {
+    if (elem === 'Account') {
+      result.push(currentItem);
+      currentItem = {};
+      currentAttr = {};
+    }
+
+    if (mapping[elem] === undefined) { return; }
+
+    currentItem[mapping[elem]] = nodeValue || '';
+
+    for (var key in currentAttr) {
+      currentItem[key] = currentAttr[key];
+    }
+  });
+  saxParser.parse(xml);
+  return result;
+}
+
 
 function Player(roomName, descriptorUrl, uuid, discovery) {
   var _this = this;
@@ -949,6 +1001,45 @@ Player.prototype.getState = function () {
   //   volume: 0,
   //   trackNo: 0
   // }
+}
+
+Player.prototype.getAccounts = function (callback) {
+  http.get({
+    localAddress: this.discovery.localEndpoint,
+    hostname: this.address,
+    path: '/status/accounts',
+    port: 1400,
+  }, function (res) {
+    var accounts = [];
+    var xml = '';
+
+    res.on('data', function(chunk) {
+      xml += chunk;
+    });
+
+    res.on('end', function() {
+      try {
+        var accs = parseAccountsXml(xml);
+        accs.forEach(function(acc) {
+          if (!acc.hasOwnProperty('deleted') || acc.deleted !== '1') {
+            accounts.push(acc);
+          }
+        });
+
+        if (callback) { callback(true, accounts); }
+        return;
+      }
+      catch(err) {
+        if (callback) { callback(false); }
+        return;
+      }
+    });
+
+    res.on('error', function(err) {
+      if (callback) { callback(false); }
+      return;
+    });
+  });
 }
 
 Player.prototype.refreshShareIndex = function (callback) {


### PR DESCRIPTION
#### What I added:
Functions that call `[sonos-device-ip]:1400/status/accounts` and parse the resulting XML so I can use the `sn`, `sid` and `username` (looks like a token) of accounts registered on Sonos to format my requests.

#### What I want to do with it:

In our app a user can browse and queue music on Sonos in two different ways. They can browse Sonos directly and queue music they added via the Sonos app (anything in their Library, Favourites or Playlists). Alternatively they can browse another service they registered within our app (e.g. Spotify) and queue music directly without needing to add anything on Sonos.

I want to queue tracks, playlists or albums for both methods without needing to send music meta info (e.g. track title) along. Sonos should retrieve this info itself (because it obviously can in the Sonos app). The issue I struggle with at the moment is that I don't know how to build valid metaData to send to `addURIToQueue`. I checked with Wireshark what gets sent from the Sonos app when queueing something but there are still open questions.

**Metadata from Wireshark:**
``` xml
<DIDL-Lite xmlns:dc="http://purl.org/dc/elements/1.1/"
xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/"
xmlns:r="urn:schemas-rinconnetworks-com:metadata-1-0/"
xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/">
<item id="10032020spotify%3atrack%3a4myBMnNWZlgvVelYeTu55w"
parentID="100e206cyour_songs" restricted="true"><dc:title>Brown Eyed Girl</dc:title>
<upnp:class>object.item.audioItem.musicTrack</upnp:class>
<desc id="cdudn" nameSpace="urn:schemas-rinconnetworks-com:metadata-1-0/">
SA_RINCON2311_X_#Svc2311-[my-account-token]-Token</desc></item></DIDL-Lite>
```
*What I found out through experimenting:*
 - the value of the parentID attribute is irrelevant, its presence is not
 - the dc:title tag is optional, the title is still correct when removed
 - the upnp:class is either `object.item.audioItem.musicTrack` for tracks or `object.container.album.musicAlbum` for playlists or albums

*What I don't know yet:*
 - the special ID in front of the URI in the `id` attribute of the `item` tag and sometimes between the service prefix (e.g. `x-sonos-spotify`, `x-sonos-http`, etc.)
  - is it fixed? if not what is valid? can I calculate it?
  - is it different per service?

I hope someone can help me answer my questions. Thanks in advance!  

#### TL;DR
I want to queue tracks/playlists/albums on Sonos by sending only a (slightly formatted) service URI to `addURIToQueue. Examples:
- Spotify Browsing = `10032020spotify:track:4myBMnNWZlgvVelYeTu55w`
- Spotify Track in Sonos Library = `x-sonos-spotify:spotify:track:7ntT9X35Y8FspsqYI2qRi3?sid=9&flags=32&sn=6`
- Other Music Service in Sonos Library = `x-sonos-http:track%3a227408425.mp3?sid=160&flags=8224&sn=3`