### PR TITLE
Added functionality to enable playlists in presets

### DIFF
--- a/lib/player.js
+++ b/lib/player.js
@@ -839,6 +839,57 @@ Player.prototype.replaceWithFavorite = function (favorite, callback) {
   });
 };
 
+Player.prototype.replaceWithPlaylist = function (playlist, callback) {
+  var _this = this;
+  if (!callback)
+    callback = function () {
+    };
+
+  _this.getPlaylists(function (error, playlists) {
+    if (error) {
+      _this.log.error('error when fetching playlists');
+      return;
+    }
+
+    playlists.forEach(function (item) {
+      if (item.title.toLowerCase() == decodeURIComponent(playlist).toLowerCase()) {
+        _this.log.info('found it', item);
+
+        if (item.uri.startsWith('x-sonosapi-stream:') || item.uri.startsWith('x-sonosapi-radio:') || item.uri.startsWith('pndrradio:')) {
+          // This is a radio station, use setAVTransportURI instead.
+          _this.setAVTransportURI(item.uri, item.metaData, function (error) {
+            callback(error);
+          });
+
+          return;
+        }
+
+        _this.removeAllTracksFromQueue(function (error) {
+          if (error) {
+            _this.log.error('error when removing tracks');
+            callback(error);
+            return;
+          }
+
+          _this.addURIToQueue(item.uri, item.metaData, function (error) {
+            if (error) {
+              _this.log.error('problem adding URI to queue');
+              callback(error);
+              return;
+            }
+
+            var queueURI = 'x-rincon-queue:' + _this.uuid + '#0';
+            _this.setAVTransportURI(queueURI, '', function (error) {
+              callback(error);
+            });
+          });
+        });
+      }
+    });
+  });
+};
+
+
 Player.prototype.addPlaylistToQueue = function (playlistURI, callback) {
   var _this = this;
   _this.addURIToQueue(playlistURI, '', function (error) {

--- a/lib/sonos.js
+++ b/lib/sonos.js
@@ -658,11 +658,23 @@ Discovery.prototype.applyPreset = function (preset, callback) {
         }
       });
     });
-  } else if (preset.uri) {
+  }
+
+  if (preset.uri) {
     asyncSeries.push(function (callback) {
       coordinator.setAVTransportURI(preset.uri, null, function (error) {
         if (callback) {
           callback(error, 'setting uri');
+        }
+      });
+    });
+  }
+
+  if (preset.playlist) {
+    asyncSeries.push(function (callback) {
+      coordinator.replaceWithPlaylist(preset.playlist, function (error) {
+        if (callback) {
+          callback(error, 'applying playlist');
         }
       });
     });


### PR DESCRIPTION
I have modified the below by duplicating the functions required to use a favourite in a preset, and enabled the same for playlists instead.

This now allows me to set a "playlist" field in the presets.json and have it correctly loaded to the Sonos system.

Note, the functionality of the playlist feature is exactly the same as favourite, in that it will replace the current queue and begin playing based on the options specified in the presets.json

I needed this as I wanted to play dynamic playlists from within a preset as part of a home kit integration using home bridge.

Should be a simple merge. Tested and working in my environment