### PR TITLE
Update player.js

### DIFF
--- a/lib/player.js
+++ b/lib/player.js
@@ -805,7 +805,7 @@ Player.prototype.replaceWithFavorite = function (favorite, callback) {
       if (item.title.toLowerCase() == decodeURIComponent(favorite).toLowerCase()) {
         _this.log.info('found it', item);
 
-        if (item.uri.startsWith('x-sonosapi-stream:') || item.uri.startsWith('x-sonosapi-radio:') || item.uri.startsWith('pndrradio:')) {
+        if (item.uri.startsWith('x-sonosapi-stream:') || item.uri.startsWith('x-sonosapi-radio:') || item.uri.startsWith('pndrradio:') || item.uri.startsWith('x-sonosapi-hls:')) {
           // This is a radio station, use setAVTransportURI instead.
           _this.setAVTransportURI(item.uri, item.metaData, function (error) {
             callback(error);


### PR DESCRIPTION
Added check for 'x-sonosapi-hls' for SiriusXM.  Without this change the display information on the Sonos controller apps does not display correctly and instead displays garbage metadata.