### PR TITLE
string compare better with uppercase

### DIFF
--- a/lib/SonosSystem.js
+++ b/lib/SonosSystem.js
@@ -146,7 +146,7 @@ function SonosSystem() {
 util.inherits(SonosSystem, EventEmitter);
 
 SonosSystem.prototype.getPlayer = function getPlayer(name) {
-  return this.players.find((player) => player.roomName.toLowerCase() === name.toLowerCase());
+  return this.players.find((player) => player.roomName.toUpperCase() === name.toUpperCase());
 };
 
 SonosSystem.prototype.getPlayerByUUID = function getPlayerByUUID(uuid) {


### PR DESCRIPTION
Hi,

while scanning over the code I noticed something I read about recently. Its better to use "toUpperCase()" than "toLowerCase()":
https://msdn.microsoft.com/en-us/library/bb386042.aspx
http://stackoverflow.com/questions/234591/upper-vs-lower-case

It might even be better to use "toLocaleUpperCase()".

Its just a proposition. I didn't check every file for a similar comparison.
I like your code. Its clean and easy to read :)

Greetings