### PR TITLE
Race condition with listening server "port in use"

### DIFF
--- a/lib/NotificationListener.js
+++ b/lib/NotificationListener.js
@@ -74,11 +74,11 @@ function NotificationListener(localEndpoint) {
   function init() {
     server = http.createServer(notificationHandler);
     server.listen(listeningPort);
-    
+
     server.on('listening', () => {
       _this.emit('listening', listeningPort);
     });
-    
+
     server.on('error', (e) => {
       if (e.code === 'EADDRINUSE') {
         server.listen(++listeningPort);

--- a/lib/NotificationListener.js
+++ b/lib/NotificationListener.js
@@ -74,7 +74,11 @@ function NotificationListener(localEndpoint) {
   function init() {
     server = http.createServer(notificationHandler);
     server.listen(listeningPort);
-
+    
+    server.on('listening', () => {
+      _this.emit('listening', listeningPort);
+    });
+    
     server.on('error', (e) => {
       if (e.code === 'EADDRINUSE') {
         server.listen(++listeningPort);

--- a/lib/SonosSystem.js
+++ b/lib/SonosSystem.js
@@ -129,8 +129,10 @@ function SonosSystem() {
       listener.on('queue-change', queueChange);
       listener.on('favorites-change', favoritesChange);
       listener.on('topology', topologyChange);
-      let subscribeUrl = `http://${info.ip}:1400/ZoneGroupTopology/Event`;
-      subscriber = new Subscriber(subscribeUrl, listener.endpoint());
+      listener.on('listening', (port) => {
+        let subscribeUrl = `http://${info.ip}:1400/ZoneGroupTopology/Event`;
+        subscriber = new Subscriber(subscribeUrl, listener.endpoint());
+      });
     }).catch((e) => {
       console.error(e);
     });


### PR DESCRIPTION
When the NotificationListener port is in use, it will try the next on, but the SonosSystem init() method just uses the current (blocked) port.
So I added an new event emitter to the listening event.

Greetings.