### PR TITLE
find zone by looking at members

### DIFF
--- a/lib/prototypes/Player/setGroupVolume.js
+++ b/lib/prototypes/Player/setGroupVolume.js
@@ -13,7 +13,7 @@ function setGroupVolume(desiredVolume) {
   }
 
   const zone = this.system.zones.find(zone => {
-    return (zone.uuid === this.uuid) || zone.members.find(member => member.uuid === this.uuid).length;
+    return ((zone.uuid === this.uuid) || !!zone.members.find(member => member.uuid === this.uuid).length);
   });
 
   const promises = zone.members.map((player) => {

--- a/lib/prototypes/Player/setGroupVolume.js
+++ b/lib/prototypes/Player/setGroupVolume.js
@@ -12,7 +12,9 @@ function setGroupVolume(desiredVolume) {
     deltaVolume = desiredVolume - currentGroupVolume;
   }
 
-  const zone = this.system.zones.find(zone => zone.uuid === this.uuid);
+  const zone = this.system.zones.find(zone => {
+    return (zone.uuid === this.uuid) || zone.members.find(member => member.uuid === this.uuid).length;
+  });
 
   const promises = zone.members.map((player) => {
     let targetVolume;


### PR DESCRIPTION
This change makes it possible to set the group volume on all players of a group, not just the coordinator.