### PR TITLE
add mute to notificationHandler

### DIFF
--- a/lib/models/Player.js
+++ b/lib/models/Player.js
@@ -256,6 +256,25 @@ function Player(data, listener, system) {
         });
     }
 
+    if (data.mute) {
+      let master = data.mute.find(x => x.channel === 'Master');
+      const previousMute = state.mute;
+      state.mute = master.val === '1';
+
+      _this.emit('mute-change', {
+        previousMute,
+        newMute: state.mute,
+        roomName: _this.roomName
+      });
+
+      _this.system.emit('mute-change', {
+        uuid: _this.uuid,
+        previousMute,
+        newMute: state.mute,
+        roomName: _this.roomName
+      });
+    }
+
     if (data.volume) {
       let master = data.volume.find(x => x.channel === 'Master');
       const previousVolume = state.volume;


### PR DESCRIPTION
I think this was missing. Player.state.mute didn't change for me. Could find it in the code either.

I'm not sure if its ok to introduce a new event for mute-change, but I thought it wouldn't fit the volume-change event.

I would like to implement a GroupMute similar to GroupVolume and recalulateGroupMute similar to recalulateGroupVolume. Is this ok? Or should it be part of the GroupVolume functiion?