### PR TITLE
Browse patch

### DIFF
--- a/lib/models/Player.js
+++ b/lib/models/Player.js
@@ -598,6 +598,32 @@ Player.prototype.browse = function browse(objectId, startIndex, limit) {
     });
 };
 
+Player.prototype.browseAll = function browseAll(objectId) {
+  let result = {
+    items: [],
+    startIndex: 0,
+    numberReturned: 0,
+    totalMatches: 1
+  };
+
+  let getChunk = (chunk) => {
+    Array.prototype.push.apply(result.items, chunk.items);
+    result.numberReturned += chunk.numberReturned;
+    result.totalMatches = chunk.totalMatches;
+
+    if (isFinished(chunk)) {
+      return result;
+    }
+
+    // Recursive promise chain
+    return this.browse(objectId, chunk.startIndex + chunk.numberReturned, 0)
+        .then(getChunk);
+  };
+
+  return Promise.resolve(result)
+      .then(getChunk);
+};
+
 Player.prototype.getQueue = function getQueue(startIndex, limit) {
   return this.browse('Q:0', startIndex, limit);
 };

--- a/lib/models/Player.js
+++ b/lib/models/Player.js
@@ -629,7 +629,7 @@ Player.prototype.getQueue = function getQueue(startIndex, limit) {
 };
 
 Player.prototype.getCompleteQueue = function getCompleteQueue() {
-  return this.browseAll('Q:0');
+  return this.browseAll('Q:0').then(result => result.items);
 };
 
 Player.prototype.toJSON = function toJSON() {

--- a/lib/models/Player.js
+++ b/lib/models/Player.js
@@ -375,16 +375,16 @@ Player.prototype.unMute = function unMute() {
 
 Player.prototype.unMuteGroup = function unMuteGroup() {
   return soap.invoke(
-      `${this.baseUrl}/MediaRenderer/GroupRenderingControl/Control`,
-      TYPE.GroupMute,
-      { mute: 0 });
+    `${this.baseUrl}/MediaRenderer/GroupRenderingControl/Control`,
+    TYPE.GroupMute,
+    { mute: 0 });
 };
 
 Player.prototype.muteGroup = function muteGroup() {
   return soap.invoke(
-      `${this.baseUrl}/MediaRenderer/GroupRenderingControl/Control`,
-      TYPE.GroupMute,
-      { mute: 1 });
+    `${this.baseUrl}/MediaRenderer/GroupRenderingControl/Control`,
+    TYPE.GroupMute,
+    { mute: 1 });
 };
 
 Player.prototype.setVolume = function setVolume(level) {

--- a/lib/models/Player.js
+++ b/lib/models/Player.js
@@ -611,7 +611,7 @@ Player.prototype.browseAll = function browseAll(objectId) {
     result.numberReturned += chunk.numberReturned;
     result.totalMatches = chunk.totalMatches;
 
-    if (isFinished(chunk)) {
+    if (chunk.startIndex + chunk.numberReturned >= chunk.totalMatches) {
       return result;
     }
 
@@ -626,6 +626,10 @@ Player.prototype.browseAll = function browseAll(objectId) {
 
 Player.prototype.getQueue = function getQueue(startIndex, limit) {
   return this.browse('Q:0', startIndex, limit);
+};
+
+Player.prototype.getCompleteQueue = function getCompleteQueue() {
+  return this.browseAll('Q:0');
 };
 
 Player.prototype.toJSON = function toJSON() {

--- a/lib/models/Player.js
+++ b/lib/models/Player.js
@@ -612,7 +612,7 @@ Player.prototype.browseAll = function browseAll(objectId) {
     result.totalMatches = chunk.totalMatches;
 
     if (chunk.startIndex + chunk.numberReturned >= chunk.totalMatches) {
-      return result;
+      return result.items;
     }
 
     // Recursive promise chain
@@ -625,11 +625,7 @@ Player.prototype.browseAll = function browseAll(objectId) {
 };
 
 Player.prototype.getQueue = function getQueue(startIndex, limit) {
-  return this.browse('Q:0', startIndex, limit);
-};
-
-Player.prototype.getCompleteQueue = function getCompleteQueue() {
-  return this.browseAll('Q:0').then(result => result.items);
+  return this.browseAll('Q:0');
 };
 
 Player.prototype.toJSON = function toJSON() {

--- a/lib/prototypes/Player/replaceWithFavorite.js
+++ b/lib/prototypes/Player/replaceWithFavorite.js
@@ -14,7 +14,7 @@ function replaceWithFavorite(favoriteName) {
   return this.system.getFavorites()
     .then((favorites) => {
       logger.debug(`found favorites`, favorites.map(x => x.title));
-      return favorites.find((fav) => fav.title.toLowerCase() === favoriteName.toLowerCase());
+      return favorites.find((fav) => fav.title.toLowerCase() === favoriteName.toLowerCase() || fav.uri.toLowerCase() === favoriteName.toLowerCase());
     })
     .then((favorite) => {
       if (!favorite) {

--- a/lib/prototypes/Player/replaceWithPlaylist.js
+++ b/lib/prototypes/Player/replaceWithPlaylist.js
@@ -1,7 +1,6 @@
 'use strict';
 const logger = require('../../helpers/logger');
 
-
 function replaceWithPlaylist(playlistName) {
   logger.debug(`replacing with playlist ${playlistName}`);
   return this.system.getPlaylists()

--- a/lib/prototypes/Player/replaceWithPlaylist.js
+++ b/lib/prototypes/Player/replaceWithPlaylist.js
@@ -1,0 +1,33 @@
+'use strict';
+const logger = require('../../helpers/logger');
+
+
+function replaceWithPlaylist(playlistName) {
+  logger.debug(`replacing with playlist ${playlistName}`);
+  return this.system.getPlaylists()
+    .then((playlists) => {
+      logger.debug(`found playlists`, playlists.map(x => x.title));
+      return playlists.find((list) => list.title.toLowerCase() === playlistName.toLowerCase());
+    })
+    .then((playlist) => {
+      if (!playlist) {
+        throw new Error('Playlist not found');
+      }
+
+      logger.debug('clearing queue');
+      return this.clearQueue()
+        .then(() => logger.debug(`Adding ${playlist.uri} to queue`))
+        .then(() => this.addURIToQueue(playlist.uri, ''))
+        .then(() => logger.debug(`triggering queue mode`))
+        .then(() => {
+          return { uri: `x-rincon-queue:${this.uuid}#0` };
+        });
+    })
+    .then((favorite) => {
+      logger.debug(`setting AVTransport to ${favorite.uri} `);
+      return this.setAVTransport(favorite.uri, '');
+    })
+    .then(() => this.play());
+}
+
+module.exports = replaceWithPlaylist;

--- a/lib/prototypes/SonosSystem/getFavorites.js
+++ b/lib/prototypes/SonosSystem/getFavorites.js
@@ -1,8 +1,7 @@
 'use strict';
 
 function getFavorites() {
-  return this.getAnyPlayer().browseAll('FV:2')
-    .then(result => result.items);
+  return this.getAnyPlayer().browseAll('FV:2');
 }
 
 module.exports = getFavorites;

--- a/lib/prototypes/SonosSystem/getFavorites.js
+++ b/lib/prototypes/SonosSystem/getFavorites.js
@@ -1,8 +1,7 @@
 'use strict';
 
 function getFavorites() {
-  let player = this.getAnyPlayer();
-  return player.browse('FV:2', 0, 0)
+  return this.getAnyPlayer().browseAll('FV:2')
     .then(result => result.items);
 }
 

--- a/lib/prototypes/SonosSystem/getPlaylists.js
+++ b/lib/prototypes/SonosSystem/getPlaylists.js
@@ -1,8 +1,7 @@
 'use strict';
 
 function getPlaylists() {
-  return this.getAnyPlayer().browseAll('SQ:')
-    .then(result => result.items);
+  return this.getAnyPlayer().browseAll('SQ:');
 }
 
 module.exports = getPlaylists;

--- a/lib/prototypes/SonosSystem/getPlaylists.js
+++ b/lib/prototypes/SonosSystem/getPlaylists.js
@@ -1,36 +1,8 @@
 'use strict';
 
-function isFinished(chunk) {
-  return chunk.startIndex + chunk.numberReturned >= chunk.totalMatches;
-}
-
 function getPlaylists() {
-  let player = this.getAnyPlayer();
-
-  let result = {
-    items: [],
-    startIndex: 0,
-    numberReturned: 0,
-    totalMatches: 1
-  };
-
-  let getChunk = (chunk) => {
-    Array.prototype.push.apply(result.items, chunk.items);
-    result.numberReturned += chunk.numberReturned;
-    result.totalMatches = chunk.totalMatches;
-
-    if (isFinished(chunk)) {
-      return result;
-    }
-
-    // Recursive promise chain
-    return player.browse('SQ:', chunk.startIndex + chunk.numberReturned, 0)
-      .then(getChunk);
-  };
-
-  return Promise.resolve(result)
-    .then(getChunk);
-
+  return this.getAnyPlayer().browseAll('SQ:')
+    .then(result => result.items);
 }
 
 module.exports = getPlaylists;

--- a/test/unit/models/Player.js
+++ b/test/unit/models/Player.js
@@ -508,11 +508,8 @@ describe('Player', () => {
       });
 
       it('Parses queue and returns a list of well designed objects', () => {
-        expect(queue.items).not.empty;
-        expect(queue.startIndex).equal(0);
-        expect(queue.numberReturned).equal(49);
-        expect(queue.totalMatches).equal(49);
-        expect(queue.items[0]).eql({
+        expect(queue).not.empty;
+        expect(queue[0]).eql({
           uri: 'x-sonos-spotify:spotify%3atrack%3a2uAWmcvujYUNTPCIb2VYKH?sid=9&flags=8224&sn=2',
           artist: 'Deftones',
           metadata: undefined,

--- a/test/unit/prototypes/SonosSystem/getFavorites.js
+++ b/test/unit/prototypes/SonosSystem/getFavorites.js
@@ -24,7 +24,7 @@ describe('getFavorites', () => {
   describe('When calling getFavorites', () => {
     before(() => {
       player = {
-        browse: sinon.stub().resolves(resultMock)
+        browseAll: sinon.stub().resolves(resultMock)
       };
 
       system = {
@@ -37,9 +37,9 @@ describe('getFavorites', () => {
         .then(success);
     });
 
-    it('Has called browse', () => {
-      expect(player.browse).calledOnce;
-      expect(player.browse.firstCall.args).eql(['FV:2', 0, 0]);
+    it('Has called browseAll', () => {
+      expect(player.browseAll).calledOnce;
+      expect(player.browseAll.firstCall.args).eql(['FV:2']);
     });
 
     it('Returns the expected result with undefined values filtered out', () => {

--- a/test/unit/prototypes/SonosSystem/getFavorites.js
+++ b/test/unit/prototypes/SonosSystem/getFavorites.js
@@ -24,7 +24,7 @@ describe('getFavorites', () => {
   describe('When calling getFavorites', () => {
     before(() => {
       player = {
-        browseAll: sinon.stub().resolves(resultMock)
+        browseAll: sinon.stub().resolves(resultMock.items)
       };
 
       system = {

--- a/test/unit/prototypes/SonosSystem/getPlaylists.js
+++ b/test/unit/prototypes/SonosSystem/getPlaylists.js
@@ -24,7 +24,7 @@ describe('getPlaylists', () => {
       };
 
       player = {
-        browse: sinon.stub().resolves(resultMock)
+        browseAll: sinon.stub().resolves(resultMock)
       };
 
       system = {
@@ -37,63 +37,14 @@ describe('getPlaylists', () => {
         .then(success);
     });
 
-    it('Has called browse', () => {
-      expect(player.browse).calledOnce;
-      expect(player.browse.firstCall.args).eql(['SQ:', 0, 0]);
+    it('Has called browseAll', () => {
+      expect(player.browseAll).calledOnce;
+      expect(player.browseAll.firstCall.args).eql(['SQ:']);
     });
 
     it('Returns the expected result', () => {
-      expect(success.firstCall.args[0]).eql(resultMock);
+      expect(success.firstCall.args[0]).eql(resultMock.items);
     });
   });
 
-  describe('When result is bigger than maximum chunk', () => {
-    let player;
-    before(() => {
-
-      player = {
-        browse: sinon.stub()
-      };
-
-      player.browse.onCall(0).resolves({
-        items: [1, 2, 3],
-        startIndex: 0,
-        numberReturned: 3,
-        totalMatches: 6
-      });
-
-      player.browse.onCall(1).resolves({
-        items: [4, 5, 6],
-        startIndex: 3,
-        numberReturned: 3,
-        totalMatches: 6
-      });
-
-      // This prevents the loop from continuing without noticing.
-      // Should not happen.
-      player.browse.onCall(2).rejects();
-
-      system = {
-        getAnyPlayer: sinon.stub().returns(player)
-      };
-
-      success = sinon.spy();
-
-      return getPlaylists.call(system)
-        .then(success);
-    });
-
-    it('Should call browse twice', () => {
-      expect(player.browse).calledTwice;
-    });
-
-    it('Has merged result', () => {
-      expect(success.firstCall.args[0]).eql({
-        items: [1, 2, 3, 4, 5, 6],
-        startIndex: 0,
-        numberReturned: 6,
-        totalMatches: 6
-      });
-    });
-  });
 });

--- a/test/unit/prototypes/SonosSystem/getPlaylists.js
+++ b/test/unit/prototypes/SonosSystem/getPlaylists.js
@@ -24,7 +24,7 @@ describe('getPlaylists', () => {
       };
 
       player = {
-        browseAll: sinon.stub().resolves(resultMock)
+        browseAll: sinon.stub().resolves(resultMock.items)
       };
 
       system = {


### PR DESCRIPTION
- Added a method to automatically get all browse items.
- changed the getFavorites and getPlaylist methods to use this.
- added method getCompleteQueue().
- made getFavorites and getPlaylist return the same result style (one returned object with .items the other just the items)
- added replaceWithPlaylist() method