### PR TITLE
enqueued metadata are used, if supplied, to fill in state fields.

### DIFF
--- a/lib/models/Player.js
+++ b/lib/models/Player.js
@@ -234,13 +234,12 @@ function Player(data, listener, system) {
         })
         .then(() => {
           if (data['r:enqueuedtransporturi'] && (state.currentTrack.title === data['r:enqueuedtransporturi'].val)) {
-            return parseTrackMetadata(data['r:enqueuedtransporturimetadata']);
-          }
-        })
-        .then(track => {
-          if (track) {
-            Object.keys(track).forEach((key) => {
-              if (track[key] !== EMPTY_STATE.currentTrack[key]) state.currentTrack[key] = track[key];
+            return parseTrackMetadata(data['r:enqueuedtransporturimetadata']).then(track => {
+              if (!track) return;
+
+              Object.keys(track).forEach((key) => {
+                if (track[key] !== EMPTY_STATE.currentTrack[key]) state.currentTrack[key] = track[key];
+              });
             });
           }
         })

--- a/lib/models/Player.js
+++ b/lib/models/Player.js
@@ -85,12 +85,15 @@ function parseTrackMetadata(metadata, nextTrack) {
     const sax = flow(streamer(metadata.val));
 
     sax.on('tag:item', (item) => {
-      track.uri = item.res.$text;
-      track.duration = parseTime((item.res.$attrs || item.res).duration);
-      track.artist = item['dc:creator'];
-      track.album = item['upnp:album'];
-      track.title = item['dc:title'];
-      track.albumArtUri = item['upnp:albumarturi'];
+      if (item.res && item.res.$text) track.uri = item.res.$text;
+      if (item.res && (item.res.$attrs || item.res).duration) track.duration = parseTime((item.res.$attrs || item.res).duration);
+      if (item['dc:creator']) track.artist = item['dc:creator'];
+      if (item['upnp:album']) track.album = item['upnp:album'];
+      if (item['dc:title']) track.title = item['dc:title'];
+      if (item['upnp:albumarturi']) track.albumArtUri = item['upnp:albumarturi'];
+      if (item['r:resmd']) track.metaData = item['r:resmd'];
+      if (item['r:streamcontent']) track.streamInfo = item['r:streamcontent'];
+      if (item['r:radioshowmd']) track.radioShowMetaData = item['r:radioshowmd'];
     });
 
     sax.on('error', reject);
@@ -228,6 +231,18 @@ function Player(data, listener, system) {
             }).catch(() => {
               track.absoluteAlbumArtUri = `${_this.baseUrl}${track.albumArtUri}`;
             });
+        })
+        .then(() => {
+          if (data['r:enqueuedtransporturi'] && (state.currentTrack.title === data['r:enqueuedtransporturi'].val)) {
+            return parseTrackMetadata(data['r:enqueuedtransporturimetadata']);
+          }
+        })
+        .then(track => {
+          if (track) {
+            Object.keys(track).forEach((key) => {
+              if (track[key] !== EMPTY_STATE.currentTrack[key]) state.currentTrack[key] = track[key];
+            });
+          }
         })
         .then(() => parseTrackMetadata(data['r:nexttrackmetadata'], true))
         .then(track => {

--- a/lib/types/empty-state.js
+++ b/lib/types/empty-state.js
@@ -11,6 +11,8 @@ const EMPTY_STATE = Object.freeze({
     duration: 0,
     uri: '',
     type: URI_TYPE.TRACK,
+    metaData: '',
+    streamInfo: '',
     radioShowMetaData: ''
   }),
   nextTrack: Object.freeze({

--- a/test/unit/models/Player.js
+++ b/test/unit/models/Player.js
@@ -139,7 +139,9 @@ describe('Player', () => {
         duration: 318,
         uri: 'x-sonos-spotify:spotify%3atrack%3a5qAFqkXoQd2RfjZ2j1ay0w?sid=9&flags=8224&sn=9',
         type: 'track',
-        radioShowMetaData: ''
+        radioShowMetaData: '',
+        metaData: '',
+        streamInfo: ''
       });
       expect(player.state.nextTrack).eql({
         artist: 'Coheed and Cambria',


### PR DESCRIPTION
This allows radios to replace artist and stream info.
And it no longer replaces track fields if they are not part of the item

I made the expi that in these cases:
`data['r:enqueuedtransporturi'].val === currenttrackmetadata.title`
