### PR TITLE
Add Track Number to Browse Item Results

### DIFF
--- a/lib/models/Player.js
+++ b/lib/models/Player.js
@@ -697,7 +697,7 @@ Player.prototype.browse = function browse(objectId, startIndex, limit) {
             title: item['dc:title'],
             artist: item['dc:creator'],
             album: item['upnp:album'],
-            tracknum: item['upnp:originaltracknumber'],
+            albumTrackNumber: item['upnp:originaltracknumber'],
             albumArtUri: item['upnp:albumarturi'] instanceof Array
               ? item['upnp:albumarturi'][0]
               : item['upnp:albumarturi'],

--- a/lib/models/Player.js
+++ b/lib/models/Player.js
@@ -697,6 +697,7 @@ Player.prototype.browse = function browse(objectId, startIndex, limit) {
             title: item['dc:title'],
             artist: item['dc:creator'],
             album: item['upnp:album'],
+            tracknum: item['upnp:originaltracknumber'],
             albumArtUri: item['upnp:albumarturi'] instanceof Array
               ? item['upnp:albumarturi'][0]
               : item['upnp:albumarturi'],


### PR DESCRIPTION
Allows tracks from the music library to be sorted in album order when playing an album