### PR TITLE
Adding a trackUri which is separate from a stationUri for Pandora

### DIFF
--- a/lib/models/Player.js
+++ b/lib/models/Player.js
@@ -96,6 +96,7 @@ function parseTrackMetadata(metadata, nextTrack) {
 
     sax.on('tag:item', (item) => {
       track.uri = item.res && item.res.$text;
+      track.trackUri = track.uri;
       track.duration = parseTime((item.res.$attrs || item.res).duration);
       track.artist = item['dc:creator'];
       track.album = item['upnp:album'];

--- a/lib/types/empty-state.js
+++ b/lib/types/empty-state.js
@@ -11,6 +11,7 @@ const EMPTY_STATE = Object.freeze({
     albumArtUri: '',
     duration: 0,
     uri: '',
+    trackUri: '',
     type: URI_TYPE.TRACK,
     stationName: '',
   }),

--- a/test/unit/models/Player.js
+++ b/test/unit/models/Player.js
@@ -147,6 +147,7 @@ describe.only('Player', () => {
         absoluteAlbumArtUri: 'http://example.org/image1',
         duration: 318,
         uri: 'x-sonos-spotify:spotify%3atrack%3a5qAFqkXoQd2RfjZ2j1ay0w?sid=9&flags=8224&sn=9',
+        trackUri: 'x-sonos-spotify:spotify%3atrack%3a5qAFqkXoQd2RfjZ2j1ay0w?sid=9&flags=8224&sn=9',
         type: 'track',
         stationName: '',
       });
@@ -201,6 +202,7 @@ describe.only('Player', () => {
         absoluteAlbumArtUri: 'http://192.168.1.151:1400/getaa?s=1&u=x-sonosapi-stream%3as17553%3fsid%3d254%26flags%3d8224%26sn%3d0',
         duration: 0,
         uri: 'x-sonosapi-stream:s17553?sid=254&flags=8224&sn=0',
+        trackUri: 'x-sonosapi-stream:s17553?sid=254&flags=8224&sn=0',
         type: 'radio'
       });
 
@@ -245,6 +247,7 @@ describe.only('Player', () => {
         albumArtUri: undefined,
         duration: 0,
         uri: 'x-rincon-mp3radio://sc01.scahw.com.au:80/buddha_32',
+        trackUri: 'x-rincon-mp3radio://sc01.scahw.com.au:80/buddha_32',
         type: 'radio'
       });
 

--- a/test/unit/models/Player.js
+++ b/test/unit/models/Player.js
@@ -158,8 +158,8 @@ describe.only('Player', () => {
         albumArtUri: '/getaa?s=1&u=x-sonos-spotify%3aspotify%253atrack%253a0Ap3aOVU7LItcHIFiRF8lY%3fsid%3d9%26flags%3d8224%26sn%3d9',
         absoluteAlbumArtUri: 'http://example.org/image2',
         duration: 241,
-        uri: 'x-sonos-spotify:spotify%3atrack%3a0Ap3aOVU7LItcHIFiRF8lY?sid=9&flags=8224&sn=9/nextTrack',
-        trackUri: 'x-sonos-spotify:spotify%3atrack%3a0Ap3aOVU7LItcHIFiRF8lY?sid=9&flags=8224&sn=9/nextTrack'
+        uri: 'x-sonos-spotify:spotify%3atrack%3a0Ap3aOVU7LItcHIFiRF8lY?sid=9&flags=8224&sn=9',
+        trackUri: 'x-sonos-spotify:spotify%3atrack%3a0Ap3aOVU7LItcHIFiRF8lY?sid=9&flags=8224&sn=9'
       });
 
       expect(player.state.playMode).eql({

--- a/test/unit/models/Player.js
+++ b/test/unit/models/Player.js
@@ -158,7 +158,8 @@ describe.only('Player', () => {
         albumArtUri: '/getaa?s=1&u=x-sonos-spotify%3aspotify%253atrack%253a0Ap3aOVU7LItcHIFiRF8lY%3fsid%3d9%26flags%3d8224%26sn%3d9',
         absoluteAlbumArtUri: 'http://example.org/image2',
         duration: 241,
-        uri: 'x-sonos-spotify:spotify%3atrack%3a0Ap3aOVU7LItcHIFiRF8lY?sid=9&flags=8224&sn=9'
+        uri: 'x-sonos-spotify:spotify%3atrack%3a0Ap3aOVU7LItcHIFiRF8lY?sid=9&flags=8224&sn=9/nextTrack',
+        trackUri: 'x-sonos-spotify:spotify%3atrack%3a0Ap3aOVU7LItcHIFiRF8lY?sid=9&flags=8224&sn=9/nextTrack'
       });
 
       expect(player.state.playMode).eql({
@@ -247,7 +248,7 @@ describe.only('Player', () => {
         albumArtUri: undefined,
         duration: 0,
         uri: 'x-rincon-mp3radio://sc01.scahw.com.au:80/buddha_32',
-        trackUri: 'x-rincon-mp3radio://sc01.scahw.com.au:80/buddha_32',
+        trackUri: 'aac://sc01.scahw.com.au:80/buddha_32',
         type: 'radio'
       });
 


### PR DESCRIPTION
Pandora currently overwrites the actual track uri with the station uri.  To work around that I added a separate trackUri so we can do things in the node-sonos-http-api layer like thumbs up and down,  This goes with the other PR in node-sonos-http-api