### PR TITLE
 log an error in applyPreset if room in list cannot be found with tests

### DIFF
--- a/lib/prototypes/SonosSystem/applyPreset.js
+++ b/lib/prototypes/SonosSystem/applyPreset.js
@@ -94,10 +94,10 @@ function applyPreset(preset) {
         if (!result) {
           logger.error(`preset ${preset.favorite}: bad room name ${playerInfo.roomName}`);
         }
-        // it will be undefined which causes error later. Could filter this
-        // map to silently ignore them.
+        // it will be undefined which results in an error later. We filter it below
+        // so that the bad or missing room is ignored and the other players work.
         return result;            
-    });
+    }).filter(player => player !== undefined);
   });
 
   promise = promise.then(() => {

--- a/lib/prototypes/SonosSystem/applyPreset.js
+++ b/lib/prototypes/SonosSystem/applyPreset.js
@@ -89,7 +89,15 @@ function applyPreset(preset) {
   let coordinator;
 
   promise = promise.then(() => {
-    players = preset.players.map(playerInfo => this.getPlayer(playerInfo.roomName));
+    players = preset.players.map(playerInfo => {
+        const result = this.getPlayer(playerInfo.roomName);
+        if (!result) {
+          logger.error(`preset ${preset.favorite}: bad room name ${playerInfo.roomName}`);
+        }
+        // it will be undefined which causes error later. Could filter this
+        // map to silently ignore them.
+        return result;            
+    });
   });
 
   promise = promise.then(() => {

--- a/lib/prototypes/SonosSystem/applyPreset.js
+++ b/lib/prototypes/SonosSystem/applyPreset.js
@@ -94,10 +94,11 @@ function applyPreset(preset) {
         if (!result) {
           logger.error(`preset ${preset.favorite}: bad room name ${playerInfo.roomName}`);
         }
+
         // it will be undefined which results in an error later. We filter it below
         // so that the bad or missing room is ignored and the other players work.
-        return result;            
-    }).filter(player => player !== undefined);
+        return result;
+      }).filter(player => player !== undefined);
   });
 
   promise = promise.then(() => {

--- a/test/unit/prototypes/SonosSystem/applyPreset.js
+++ b/test/unit/prototypes/SonosSystem/applyPreset.js
@@ -11,6 +11,7 @@ describe('SonosSystem.applyPreset', () => {
     let coordinator;
     let member;
     let preset;
+    let badRoomPreset;
     let superfluousPlayer;
     let otherPlayer;
 
@@ -84,7 +85,7 @@ describe('SonosSystem.applyPreset', () => {
       system.getPlayer.withArgs('Office').returns(member);
 
       preset = {
-        players: [{ roomName: 'Kitchen', volume: 1 }, { roomName: 'Other room', volume: 2 }, {
+        players: [{ roomName: 'Kitchen', volume: 1 }, { roomName: 'Other room', volume: 2 }, { roomName: 'Bad room', volume: 2 }, {
           roomName: 'Office',
           volume: 3,
           mute: true
@@ -102,11 +103,17 @@ describe('SonosSystem.applyPreset', () => {
         sleep: 600
       };
     });
+    badRoomPreset = preset;
 
     describe('When applying preset', () => {
 
       beforeEach(() => {
-        return applyPreset.call(system, preset);
+        let result = applyPreset.call(system, preset);
+        if (preset === badRoomPreset) {
+          expect(result.stderr).to.contain('ERROR preset My favorite: bad room name Bad room');
+        }
+
+        return result;
       });
 
       it('Pauses all zones', () => {
@@ -181,7 +188,7 @@ describe('SonosSystem.applyPreset', () => {
     describe('When it contains an mute=false', () => {
 
       beforeEach(() => {
-        preset.players[2].mute = false;
+        preset.players[3].mute = false;
       });
 
       beforeEach(() => {
@@ -289,4 +296,5 @@ describe('SonosSystem.applyPreset', () => {
       expect(player.setAVTransport.firstCall.args[1]).equal(preset.metadata);
     });
   });
+
 });


### PR DESCRIPTION
    log an error in applyPreset if room in list cannot be found. This is
    annoying to track down because the result of the map will cause the
    returned player array to contain undefined which results in a less
    transparent error later on when we try to group it with others. This
    error will still occur, but at least the user knows they have a typo
    in a preset.  In my case it was bedrooom instead of bedroom. doh.

    We could consider filtering the undefineds which would eliminate the
    later error(s) so the remaining rooms can still play.  Not unreasonable
    if we tell the user there is bad room name and ignore it.